### PR TITLE
fix-lodash-pkg-version-issue-CVE-2019-10744

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ecstatic": "^3.3.2",
     "http-server": "^0.11.1",
     "js-yaml": "^3.13.1",
+    "lodash": "^4.5.0",
     "vuepress": "^0.14.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,6 +4375,11 @@ lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.5.0:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
bump yarn version to 4.5.0, due to a security alert CVE-2019-10744

details

```
CVE-2019-10744 More information

high severity

Vulnerable versions: < 4.5.0
Patched version: 4.5.0

Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.
```